### PR TITLE
Fixes for two bugs with AB Sciex files

### DIFF
--- a/pwiz_mzdb/mzdb/utils/mzUtils.hpp
+++ b/pwiz_mzdb/mzdb/utils/mzUtils.hpp
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <set>
 
+#include <regex>
 
 #include "pwiz/data/msdata/MSData.hpp"
 #include "pwiz/analysis/peakdetect/PeakFamilyDetectorFT.hpp"
@@ -283,6 +284,32 @@ inline static double precursorMzOf(const pwiz::msdata::SpectrumPtr &s) {
     return si.cvParam(pwiz::msdata::MS_selected_ion_m_z).valueAs<double>();
 }
 
+
+/**
+ * @brief checkCycleNumber
+ * checks if cycle number matches the "real" cycle number given in the spectrum title
+ *
+ * @param filetype origin file type (titles are differents for each file type)
+ * @param spectrumTitle in which the good cycle number may be found
+ * @param cycleNumber, the computed cycle number that may be wrong
+ */
+inline void checkCycleNumber(pwiz::msdata::CVID filetype, string spectrumTitle, int& cycleNumber) {
+    // add a special case for ABSciex files
+    if(filetype == pwiz::msdata::MS_ABI_WIFF_format) {
+        std::regex e ("cycle=(\\d+)");
+        std::smatch match;
+        if (std::regex_search(spectrumTitle, match, e) && match.size() > 0) {
+            // real cycle extracted from title
+            // if the spray gets lost, the spectra will not be written in the wiff file and the cycles wont be a list from 1 to the end
+            int cycle = std::stoi(match.str(1));
+            if(cycle != cycleNumber) {
+                //printf("Cycle changed from "+cycleNumber+" to "+cycle+"\n");
+                printf("Cycle changed from %d to %d\n", cycleNumber, cycle);
+                cycleNumber = cycle;
+            }
+        }
+    }
+}
 } // end namespace PWIZ HELPER
 
 

--- a/pwiz_mzdb/mzdb/writer/dda_producer.h
+++ b/pwiz_mzdb/mzdb/writer/dda_producer.h
@@ -3,6 +3,7 @@
 
 #include <unordered_map>
 #include <set>
+#include <regex>
 
 #include "windows.h"
 #include "exception"
@@ -54,6 +55,31 @@ private:
 
     ///ms levels encountered
     set<int> m_msLevels;
+
+    /**
+     * @brief _checkCycleNumber
+     * checks if cycle number matches the "real" cycle number given in the spectrum title
+     *
+     * @param filetype origin file type (titles are differents for each file type)
+     * @param spectrumTitle in which the good cycle number may be found
+     * @param cycleNumber, the computed cycle number that may be wrong
+     */
+    void _checkCycleNumber(pwiz::msdata::CVID filetype, string spectrumTitle, int& cycleNumber) {
+        // add a special case for ABSciex files
+        if(filetype == pwiz::msdata::MS_ABI_WIFF_format) {
+            std::regex e ("cycle=(\\d+)");
+            std::smatch match;
+            if (std::regex_search(spectrumTitle, match, e) && match.size() > 0) {
+                // real cycle extracted from title
+                // if the spray gets lost, the spectra will not be written in the wiff file and the cycles wont be a list from 1 to the end
+                int cycle = std::stoi(match.str(1));
+                if(cycle != cycleNumber) {
+                    LOG(INFO) << "ABU cycle changed from " << cycleNumber << " to " << cycle << "\n";
+                    cycleNumber = cycle;
+                }
+            }
+        }
+    }
 
     /**
      * @brief _peakPickAndPush
@@ -145,6 +171,7 @@ public:
 
             if (msLevel == 1 ) {
                 ++cycleCount;
+                this->_checkCycleNumber(filetype, spectrum->id, cycleCount);
                 currMs1 = std::make_shared<mzSpectrum<h_mz_t, h_int_t> >(scanCount, cycleCount, spectrum);
             }
 

--- a/pwiz_mzdb/mzdb/writer/dda_producer.h
+++ b/pwiz_mzdb/mzdb/writer/dda_producer.h
@@ -3,7 +3,6 @@
 
 #include <unordered_map>
 #include <set>
-#include <regex>
 
 #include "windows.h"
 #include "exception"
@@ -15,6 +14,8 @@
 #include "spectrum_inserter.h"
 #include "bb_inserter.hpp"
 #include "spectrumlist_policy.h"
+
+#include "../../utils/mzUtils.hpp"
 
 using namespace std;
 
@@ -55,31 +56,6 @@ private:
 
     ///ms levels encountered
     set<int> m_msLevels;
-
-    /**
-     * @brief _checkCycleNumber
-     * checks if cycle number matches the "real" cycle number given in the spectrum title
-     *
-     * @param filetype origin file type (titles are differents for each file type)
-     * @param spectrumTitle in which the good cycle number may be found
-     * @param cycleNumber, the computed cycle number that may be wrong
-     */
-    void _checkCycleNumber(pwiz::msdata::CVID filetype, string spectrumTitle, int& cycleNumber) {
-        // add a special case for ABSciex files
-        if(filetype == pwiz::msdata::MS_ABI_WIFF_format) {
-            std::regex e ("cycle=(\\d+)");
-            std::smatch match;
-            if (std::regex_search(spectrumTitle, match, e) && match.size() > 0) {
-                // real cycle extracted from title
-                // if the spray gets lost, the spectra will not be written in the wiff file and the cycles wont be a list from 1 to the end
-                int cycle = std::stoi(match.str(1));
-                if(cycle != cycleNumber) {
-                    LOG(INFO) << "ABU cycle changed from " << cycleNumber << " to " << cycle << "\n";
-                    cycleNumber = cycle;
-                }
-            }
-        }
-    }
 
     /**
      * @brief _peakPickAndPush
@@ -171,7 +147,7 @@ public:
 
             if (msLevel == 1 ) {
                 ++cycleCount;
-                this->_checkCycleNumber(filetype, spectrum->id, cycleCount);
+                PwizHelper::checkCycleNumber(filetype, spectrum->id, cycleCount);
                 currMs1 = std::make_shared<mzSpectrum<h_mz_t, h_int_t> >(scanCount, cycleCount, spectrum);
             }
 

--- a/pwiz_mzdb/mzdb/writer/swath_producer.hpp
+++ b/pwiz_mzdb/mzdb/writer/swath_producer.hpp
@@ -42,6 +42,39 @@ private:
 
     PeakPickerPolicy m_peakPicker;
 
+    /**
+     * @brief _checkCycleNumber
+     * checks if cycle number matches the "real" cycle number given in the spectrum title
+     *
+     * @param filetype origin file type (titles are differents for each file type)
+     * @param spectrumTitle in which the good cycle number may be found
+     * @param cycleNumber, the computed cycle number that may be wrong
+     */
+    void _checkCycleNumber(pwiz::msdata::CVID filetype, string spectrumTitle, int& cycleNumber) {
+        // add a special case for ABSciex files
+        if(filetype == pwiz::msdata::MS_ABI_WIFF_format) {
+            std::regex e ("cycle=(\\d+)");
+            std::smatch match;
+            if (std::regex_search(spectrumTitle, match, e) && match.size() > 0) {
+                // real cycle extracted from title
+                // if the spray gets lost, the spectra will not be written in the wiff file and the cycles wont be a list from 1 to the end
+                int cycle = std::stoi(match.str(1));
+                if(cycle != cycleNumber) {
+                    LOG(INFO) << "ABU cycle changed from " << cycleNumber << " to " << cycle << "\n";
+                    cycleNumber = cycle;
+                }
+            }
+        }
+    }
+
+    /**
+     * @brief _peakPickAndPush
+     * performs peak-picking then push it to the queue
+     *
+     * @param cycle, cycle number
+     * @param filetype origin file type
+     * @param params for peak picking algorithm
+     */
     void _peakPickAndPush(SpectraContainerUPtr& cycle, pwiz::msdata::CVID filetype,
                           mzPeakFinderUtils::PeakPickerParams& params) {
         this->m_peakPicker.start<h_mz_t, h_int_t, l_mz_t, l_int_t>(cycle, filetype, params);
@@ -53,6 +86,16 @@ private:
     }
 
 
+    /**
+     * Read all spectra from data file, performs peak-picking and push cycle objects
+     * into the queue
+     *
+     * @param levelsToCentroid
+     * @param spectrumList
+     * @param nscans
+     * @param filetype
+     * @param params
+     */
     void _produce(
             pwiz::util::IntegerSet& levelsToCentroid,
             SpectrumListType* spectrumList,
@@ -75,6 +118,7 @@ private:
 
             if (msLevel == 1 ) {
                 ++cycleCount;
+                this->_checkCycleNumber(filetype, spectrum->id, cycleCount);
                 currMs1 = std::make_shared<mzSpectrum<h_mz_t, h_int_t> >(scanCount, cycleCount, spectrum);
                 if (cycle) {
                     //peak picks only ms == 2


### PR DESCRIPTION
Fixed a bug that occured when final group of cycle only contains one cycle
Added a check for AB Sciex files: in some cases the spray may fade away and spectra are not recorder in the file, inducing wrong cycle numbers (ie. starting at 1 instead of 90). If this is the case (and only on WIFF files), cycles are now fixed
