### PR TITLE
Two fixes related to data_encoding_id that is stored in the mzDB file

### DIFF
--- a/pwiz_mzdb/mzdb/utils/mzUtils.hpp
+++ b/pwiz_mzdb/mzdb/utils/mzUtils.hpp
@@ -346,16 +346,9 @@ static inline string getActivationCode(const pwiz::msdata::Activation& a) {
  */
 static DataMode getDataMode( const pwiz::msdata::SpectrumPtr s, DataMode wantedMode)  {
 
-    const pwiz::msdata::CVParam& isCentroided = s->cvParam(pwiz::msdata::MS_centroid_spectrum);
-    DataMode currentMode = !isCentroided.empty() ? CENTROID : PROFILE;
-    DataMode effectiveMode;
-    if (wantedMode == PROFILE && currentMode == PROFILE) {
-        effectiveMode = PROFILE;
-    } else if ((wantedMode == CENTROID && currentMode == PROFILE) ||
-                 (wantedMode == FITTED && currentMode == PROFILE)) {
-        effectiveMode = wantedMode;
-    } else {
-        // current is CENTROID nothing to do
+    DataMode currentMode = s->hasCVParam(pwiz::msdata::MS_profile_spectrum) ? PROFILE: CENTROID;
+    DataMode effectiveMode = wantedMode;
+    if (currentMode == CENTROID && wantedMode == PROFILE) {
         effectiveMode = CENTROID;
     }
     return effectiveMode;

--- a/pwiz_mzdb/mzdb/writer/mzdb_writer.cpp
+++ b/pwiz_mzdb/mzdb/writer/mzdb_writer.cpp
@@ -46,8 +46,11 @@ void mzDBWriter::buildDataEncodingRowByID() {
     }
 
     if (hasDataMode(FITTED)) {
-        DataEncoding d(-1, FITTED, HIGH_RES_PEAK);
-        m_dataEncodingByID[id] = d;
+        DataEncoding d1(-1, FITTED, HIGH_RES_PEAK);
+        DataEncoding d2(-1, FITTED, LOW_RES_PEAK);
+        m_dataEncodingByID[id] = d1;
+        ++id;
+        m_dataEncodingByID[id] = d2;
         ++id;
     }
 

--- a/pwiz_mzdb/mzdb/writer/peak_finder_proxy.hpp
+++ b/pwiz_mzdb/mzdb/writer/peak_finder_proxy.hpp
@@ -105,35 +105,12 @@ public:
                                  pwiz::msdata::CVID fileType,
                                  mzPeakFinderUtils::PeakPickerParams& peakPickerParams) {
 
-        //const pwiz::msdata::CVParam isCentroided = s->cvParam(pwiz::msdata::MS_centroid_spectrum);
-        //isCentroided.cvid == pwiz::msdata::CVID_Unknown) ? PROFILE: CENTROID;
-
-        DataMode currentMode = s->hasCVParam(pwiz::msdata::MS_profile_spectrum) ? PROFILE: CENTROID;
-
-        DataMode effectiveMode;
-        if (wantedMode == PROFILE && currentMode == PROFILE) {
-            effectiveMode = PROFILE;
-            // just construct data points
-            computeCentroids<mz_t, int_t>(s, results);
-        } else if (wantedMode == PROFILE && currentMode == CENTROID) {
-
+        DataMode effectiveMode = getDataMode(s, wantedMode);
+        if (wantedMode == PROFILE && effectiveMode == CENTROID) {
             auto msLevel = s->cvParam(pwiz::msdata::MS_ms_level).valueAs<int>();
-            throw runtime_error("WantedMode PROFILE whereas currentMode is CENTROID for msLevel <"
-                                + boost::lexical_cast<string>(msLevel) + ">. Please change it to FITTED or CENTROID.");
-
-        } else if (wantedMode == FITTED && currentMode == CENTROID) {
-            // WARNING changing behavior here
-            effectiveMode = FITTED;
-            computeCentroids<mz_t, int_t>(s, results);
-
-        } else if ((wantedMode == CENTROID && currentMode == PROFILE) || (wantedMode == FITTED && currentMode == PROFILE)) {
-            effectiveMode = wantedMode;
-            computeCentroids<mz_t, int_t>(s, results);
-        } else {
-            // current is CENTROID nothing to do
-            effectiveMode = CENTROID;
-            computeCentroids<mz_t, int_t>(s, results);
+            throw runtime_error("WantedMode PROFILE whereas currentMode is CENTROID for msLevel <" + boost::lexical_cast<string>(msLevel) + ">. Please change it to FITTED or CENTROID.");
         }
+        computeCentroids<mz_t, int_t>(s, results);
         return effectiveMode;
     }
 

--- a/pwiz_mzdb/mzdb/writer/spectrum.hpp
+++ b/pwiz_mzdb/mzdb/writer/spectrum.hpp
@@ -163,17 +163,7 @@ struct PWIZ_API_DECL mzSpectrum {
 //        const pwiz::msdata::CVParam& isCentroided = spectrum->cvParam(pwiz::msdata::MS_centroid_spectrum);
 //        DataMode currentMode = ( isCentroided.empty() ) ? PROFILE: CENTROID;
 
-        DataMode currentMode = spectrum->hasCVParam(pwiz::msdata::MS_profile_spectrum) ? PROFILE: CENTROID;
-
-        DataMode effectiveMode;
-        if (wantedMode == PROFILE && currentMode == PROFILE) {
-            effectiveMode = PROFILE;
-        } else if ((wantedMode == CENTROID && currentMode == PROFILE) || (wantedMode == FITTED && currentMode == PROFILE)) {
-            effectiveMode = wantedMode;
-        } else { // current is CENTROID nothing to do
-            effectiveMode = CENTROID;
-        }
-        return effectiveMode;
+        return getDataMode(spectrum, wantedMode);
     }
 
 


### PR DESCRIPTION
- using function mzUtils::getDataMode in files peak_finder_proxy.hpp and spectrum.hpp, instead of duplicate code ; also simplifyed code in mzUtils::getDataMode: effectiveMode is always wantedMode, except when Profile is asked for Centroid data
- added entry "FITTED/LOW_RES_PEAK" in mzdb_writer::m_dataEncodingByID (without it, every Fitted MS/MS spectrum has data_encoding_id=1)
